### PR TITLE
Issue #137 - ctools update

### DIFF
--- a/ding_frontpage.make
+++ b/ding_frontpage.make
@@ -6,7 +6,7 @@ projects[cache_actions][subdir] = "contrib"
 projects[cache_actions][version] = "2.0-alpha5"
 
 projects[ctools][subdir] = "contrib"
-projects[ctools][version] = "1.4"
+projects[ctools][version] = "1.5"
 
 projects[ding_news][type] = "module"
 projects[ding_news][download][type] = "git"


### PR DESCRIPTION
Updated ctools which fixes PHP 5.3 warnings.